### PR TITLE
Fix np.float error

### DIFF
--- a/bytetrack/tracker/byte_tracker.py
+++ b/bytetrack/tracker/byte_tracker.py
@@ -11,7 +11,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/bytetrack/tracker/matching.py
+++ b/bytetrack/tracker/matching.py
@@ -61,12 +61,12 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
-    ious = bbox_ious(np.ascontiguousarray(atlbrs, dtype=np.float),
-                     np.ascontiguousarray(btlbrs, dtype=np.float))
+    ious = bbox_ious(np.ascontiguousarray(atlbrs, dtype=float),
+                     np.ascontiguousarray(btlbrs, dtype=float))
 
     return ious
 
@@ -123,15 +123,15 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
     det_features = np.asarray([track.curr_feat for track in detections],
-                              dtype=np.float)
+                              dtype=float)
     #for i, track in enumerate(tracks):
     #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
     track_features = np.asarray([track.smooth_feat for track in tracks],
-                                dtype=np.float)
+                                dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features,
                                         metric))  # Nomalized features
     return cost_matrix


### PR DESCRIPTION
sample.pyを実行すると、以下のようなエラーが出たので修正しました。
```
# python3 sample.py --moive test.mp4
Traceback (most recent call last):
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/sample.py", line 287, in <module>
    main()
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/sample.py", line 168, in main
    t_ids, t_bboxes, t_scores, t_class_ids = tracker(
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/bytetrack/mc_bytetrack.py", line 78, in __call__
    result = self._tracker_update(
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/bytetrack/mc_bytetrack.py", line 101, in _tracker_update
    online_targets = tracker.update(
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/bytetrack/tracker/byte_tracker.py", line 188, in update
    detections = [
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/bytetrack/tracker/byte_tracker.py", line 189, in <listcomp>
    STrack(STrack.tlbr_to_tlwh(tlbr), s)
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/bytetrack/tracker/byte_tracker.py", line 14, in __init__
    self._tlwh = np.asarray(tlwh, dtype=np.float)
  File "/home/WORK/takuya/yolox-bytetrack-mcmot-sample/venv/lib/python3.10/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```